### PR TITLE
CA-27 Compatibility with networking module

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ This module creates:
 | emrfs\_dynamodb\_table\_name | Name for the EMRFS DynamoDB table. | `string` | `""` | no |
 | hbase\_config\_path | Path to HBase configuration in EMR root directory bucket. | `string` | `"config/hbase/conf.dist/"` | no |
 | hbase\_namespace | n/a | `string` | `"tamr"` | no |
-| hbase\_storage\_mode | Storage mode for HBase.  Valid values: `SHARED`, `DEDICATED` | `string` | `"SHARED"` | no |
 | hbase\_number\_of\_regions | Number of regions to create by default in HBase | `string` | `"1000"` | no |
-| hbase\_number\_of\_salt\_values | Number of distinct salt values to be used for prefixing row keys in HBase tables.  Must be >= hbase_number_of_regions | `string` | `"1000"` | no |
+| hbase\_number\_of\_salt\_values | Number of distinct salt values to be used for prefixing row keys in HBase tables.  Must be >= hbase\_number\_of\_regions | `string` | `"1000"` | no |
+| hbase\_storage\_mode | Storage mode for HBase.  Valid values: `SHARED`, `DEDICATED` | `string` | `"SHARED"` | no |
 | master\_ebs\_size | The master EBS volume size, in gibibytes (GiB). | `string` | `""` | no |
 | master\_ebs\_type | Type of volumes to attach to the master nodes. Valid options are gp2, io1, standard and st1. | `string` | `""` | no |
 | master\_ebs\_volumes\_count | Number of volumes to attach to the master nodes. | `string` | `""` | no |

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -15,6 +15,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
+| aws | n/a |
 | random | n/a |
 | tls | n/a |
 
@@ -22,10 +23,10 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| ami\_id | AMI to use for Tamr EC2 instance | `string` | n/a | yes |
-| ec2\_subnet\_id | Subnet ID for ElasticSearch domain, Tamr VM, EMR cluster | `string` | n/a | yes |
+| data\_subnet\_ids | List of at least 2 subnet IDs in different AZs | `list(string)` | n/a | yes |
+| ec2\_subnet\_id | Subnet ID for Tamr VM | `string` | n/a | yes |
+| emr\_subnet\_id | Subnet ID for EMR cluster | `string` | n/a | yes |
 | license\_key | Tamr license key | `string` | n/a | yes |
-| rds\_subnet\_group\_ids | List of at least 2 subnet IDs in different AZs | `list(string)` | n/a | yes |
 | vpc\_id | VPC ID of deployment | `string` | n/a | yes |
 | ingress\_cidr\_blocks | List of CIDR blocks from which ingress to ElasticSearch domain, Tamr VM, Tamr Postgres instance are allowed (i.e. VPN CIDR) | `list(string)` | `[]` | no |
 | name\_prefix | A prefix to add to the names of all created resources. | `string` | `"tamr-config-test"` | no |

--- a/examples/minimal/elasticsearch.tf
+++ b/examples/minimal/elasticsearch.tf
@@ -37,7 +37,3 @@ data "aws_subnet" "application_subnet" {
 data "aws_subnet" "data_subnet_0" {
   id = var.data_subnet_ids[0]
 }
-
-data "aws_subnet" "data_subnet_1" {
-  id = var.data_subnet_ids[1]
-}

--- a/examples/minimal/elasticsearch.tf
+++ b/examples/minimal/elasticsearch.tf
@@ -14,7 +14,7 @@ module "tamr-es-cluster" {
 
   # Networking
   vpc_id     = var.vpc_id
-  subnet_ids = [var.ec2_subnet_id]
+  subnet_ids = data.aws_subnet.application_subnet.availability_zone == data.aws_subnet.data_subnet_0.availability_zone ? [var.data_subnet_ids[0]] : [var.data_subnet_ids[1]]
   security_group_ids = [
     // Spark
     module.emr.emr_service_access_sg_id,
@@ -27,4 +27,17 @@ module "tamr-es-cluster" {
   ]
   # CIDR blocks to allow ingress from (i.e. VPN)
   ingress_cidr_blocks = var.ingress_cidr_blocks
+}
+
+# To avoid cross-az traffic we place the ES cluster in the same AZ as the application subnet
+data "aws_subnet" "application_subnet" {
+  id = var.ec2_subnet_id
+}
+
+data "aws_subnet" "data_subnet_0" {
+  id = var.data_subnet_ids[0]
+}
+
+data "aws_subnet" "data_subnet_1" {
+  id = var.data_subnet_ids[1]
 }

--- a/examples/minimal/elasticsearch.tf
+++ b/examples/minimal/elasticsearch.tf
@@ -14,7 +14,7 @@ module "tamr-es-cluster" {
 
   # Networking
   vpc_id     = var.vpc_id
-  subnet_ids = data.aws_subnet.application_subnet.availability_zone == data.aws_subnet.data_subnet_0.availability_zone ? [var.data_subnet_ids[0]] : [var.data_subnet_ids[1]]
+  subnet_ids = [data.aws_subnet.data_subnet_es.id]
   security_group_ids = [
     // Spark
     module.emr.emr_service_access_sg_id,
@@ -33,7 +33,13 @@ module "tamr-es-cluster" {
 data "aws_subnet" "application_subnet" {
   id = var.ec2_subnet_id
 }
-
-data "aws_subnet" "data_subnet_0" {
-  id = var.data_subnet_ids[0]
+data "aws_subnet" "data_subnet_es" {
+   filter {
+     name = "availability-zone"
+     values = [data.aws_subnet.application_subnet.availability_zone]
+   }
+   filter {
+     name = "subnet-id"
+     values = var.data_subnet_ids
+   }
 }

--- a/examples/minimal/emr-cluster.tf
+++ b/examples/minimal/emr-cluster.tf
@@ -12,7 +12,7 @@ module "emr" {
   bucket_path_to_logs   = "logs/${var.name_prefix}-cluster/"
 
   # Networking
-  subnet_id  = var.ec2_subnet_id
+  subnet_id  = var.emr_subnet_id
   vpc_id     = var.vpc_id
   tamr_cidrs = var.ingress_cidr_blocks
   tamr_sgs = [

--- a/examples/minimal/rds.tf
+++ b/examples/minimal/rds.tf
@@ -18,7 +18,7 @@ module "rds-postgres" {
 
   vpc_id = var.vpc_id
   # Network requirement: DB subnet group needs a subnet in at least two AZs
-  rds_subnet_ids = var.rds_subnet_group_ids
+  rds_subnet_ids = var.data_subnet_ids
 
   ingress_sg_ids = [
     module.emr.emr_service_access_sg_id,

--- a/examples/minimal/tamr-vm.tf
+++ b/examples/minimal/tamr-vm.tf
@@ -1,15 +1,15 @@
 module "tamr-vm" {
   source = "git::git@github.com:Datatamer/terraform-emr-tamr-vm?ref=1.0.2"
 
-  ami                 = data.aws_ami.tamr-vm.id
-  instance_type       = "r5.2xlarge"
-  key_name            = module.emr_key_pair.key_pair_key_name
-  subnet_id           = var.ec2_subnet_id
-  vpc_id              = var.vpc_id
-  sg_name             = "${var.name_prefix}-tamrvm-sg"
-  ingress_cidr_blocks = var.ingress_cidr_blocks
-  egress_cidr_blocks  = ["0.0.0.0/0"] # TODO: scope down
-  availability_zone = data.aws_subnet.application_subnet.availability_zone
+  ami                         = data.aws_ami.tamr-vm.id
+  instance_type               = "r5.2xlarge"
+  key_name                    = module.emr_key_pair.key_pair_key_name
+  subnet_id                   = var.ec2_subnet_id
+  vpc_id                      = var.vpc_id
+  sg_name                     = "${var.name_prefix}-tamrvm-sg"
+  ingress_cidr_blocks         = var.ingress_cidr_blocks
+  egress_cidr_blocks          = ["0.0.0.0/0"] # TODO: scope down
+  availability_zone           = data.aws_subnet.application_subnet.availability_zone
   aws_role_name               = "${var.name_prefix}-tamr-ec2-role"
   aws_instance_profile_name   = "${var.name_prefix}-tamrvm-instance-profile"
   aws_emr_creator_policy_name = "${var.name_prefix}-emr-creator-policy"

--- a/examples/minimal/tamr-vm.tf
+++ b/examples/minimal/tamr-vm.tf
@@ -1,15 +1,15 @@
 module "tamr-vm" {
   source = "git::git@github.com:Datatamer/terraform-emr-tamr-vm?ref=1.0.2"
 
-  ami                 = var.ami_id
-  instance_type       = "m4.2xlarge"
+  ami                 = data.aws_ami.tamr-vm.id
+  instance_type       = "r5.2xlarge"
   key_name            = module.emr_key_pair.key_pair_key_name
   subnet_id           = var.ec2_subnet_id
   vpc_id              = var.vpc_id
   sg_name             = "${var.name_prefix}-tamrvm-sg"
   ingress_cidr_blocks = var.ingress_cidr_blocks
   egress_cidr_blocks  = ["0.0.0.0/0"] # TODO: scope down
-
+  availability_zone = data.aws_subnet.application_subnet.availability_zone
   aws_role_name               = "${var.name_prefix}-tamr-ec2-role"
   aws_instance_profile_name   = "${var.name_prefix}-tamrvm-instance-profile"
   aws_emr_creator_policy_name = "${var.name_prefix}-emr-creator-policy"
@@ -17,4 +17,14 @@ module "tamr-vm" {
     module.s3-logs.rw_policy_arn,
     module.s3-data.rw_policy_arn
   ]
+}
+
+data "aws_ami" "tamr-vm" {
+  most_recent = true
+  owners      = ["679593333241"]
+  name_regex  = "^Ubuntu 18.04 Tamr.*"
+  filter {
+    name   = "product-code"
+    values = ["832nkbrayw00cnivlh6nbbi6p"]
+  }
 }

--- a/examples/minimal/variables.tf
+++ b/examples/minimal/variables.tf
@@ -25,6 +25,11 @@ variable "vpc_id" {
   description = "VPC ID of deployment"
 }
 
+variable "emr_ubnet_id" {
+  type        = string
+  description = "Subnet ID for ElasticSearch domain, Tamr VM, EMR cluster"
+}
+
 variable "ec2_subnet_id" {
   type        = string
   description = "Subnet ID for ElasticSearch domain, Tamr VM, EMR cluster"

--- a/examples/minimal/variables.tf
+++ b/examples/minimal/variables.tf
@@ -10,11 +10,6 @@ variable "ingress_cidr_blocks" {
   default     = []
 }
 
-variable "ami_id" {
-  type        = string
-  description = "AMI to use for Tamr EC2 instance"
-}
-
 variable "license_key" {
   type        = string
   description = "Tamr license key"
@@ -25,17 +20,17 @@ variable "vpc_id" {
   description = "VPC ID of deployment"
 }
 
-variable "emr_ubnet_id" {
+variable "emr_subnet_id" {
   type        = string
-  description = "Subnet ID for ElasticSearch domain, Tamr VM, EMR cluster"
+  description = "Subnet ID for EMR cluster"
 }
 
 variable "ec2_subnet_id" {
   type        = string
-  description = "Subnet ID for ElasticSearch domain, Tamr VM, EMR cluster"
+  description = "Subnet ID for Tamr VM"
 }
 
-variable "rds_subnet_group_ids" {
+variable "data_subnet_ids" {
   type        = list(string)
   description = "List of at least 2 subnet IDs in different AZs"
 }


### PR DESCRIPTION
- Separated subnets for Data, Application and Compute.
- Moved RDS and ES to the Data subnet
- Moved TamrVM to Application subnet
- Moved EMR to Compute subnet
- Removed AMI variable and replaced it with datasource to avoid AMI-Region confusion
- Fixed Tamr-VM defaulting to us-east-1