### PR TITLE
CA-27 Compatibility with networking module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ terratest.tf.json
 
 # Ignore makefile
 ops-makefile
+
+# Ignore rendered-config.yml
+**/rendered-config.yml

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -24,10 +24,12 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | ami\_id | AMI to use for Tamr EC2 instance | `string` | n/a | yes |
-| ec2\_subnet\_id | Subnet ID for ElasticSearch domain, Tamr VM, EMR cluster | `string` | n/a | yes |
+| data\_subnet\_ids | List of at least 2 subnet IDs in different AZs | `list(string)` | n/a | yes |
+| ec2\_subnet\_id | Subnet ID for Tamr VM | `string` | n/a | yes |
+| emr\_subnet\_id | Subnet ID for EMR cluster | `string` | n/a | yes |
 | license\_key | Tamr license key | `string` | n/a | yes |
-| rds\_subnet\_group\_ids | List of at least 2 subnet IDs in different AZs | `list(string)` | n/a | yes |
 | vpc\_id | VPC ID of deployment | `string` | n/a | yes |
+| egress\_cidr\_blocks | List of CIDR blocks from which ingress to ElasticSearch domain, Tamr VM, Tamr Postgres instance are allowed (i.e. VPN CIDR) | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | emr\_abac\_valid\_tags | Valid tags for maintaining resources when using ABAC IAM Policies with Tag Conditions. Make sure `emr_tags` contain the values specified here and that your Subnet is tagged as well | `map(list(string))` | `{}` | no |
 | emr\_tags | Map of tags to add to EMR resources. They must contain abac\_valid\_tags at minimum | `map(string)` | `{}` | no |
 | ingress\_cidr\_blocks | List of CIDR blocks from which ingress to ElasticSearch domain, Tamr VM, Tamr Postgres instance are allowed (i.e. VPN CIDR) | `list(string)` | `[]` | no |

--- a/examples/minimal/elasticsearch.tf
+++ b/examples/minimal/elasticsearch.tf
@@ -14,7 +14,7 @@ module "tamr-es-cluster" {
 
   # Networking
   vpc_id             = var.vpc_id
-  subnet_ids         = [var.ec2_subnet_id]
+  subnet_ids         = [data.aws_subnet.data_subnet_es.id]
   security_group_ids = module.aws-sg-es.security_group_ids
   # CIDR blocks to allow ingress from (i.e. VPN)
   ingress_cidr_blocks = var.ingress_cidr_blocks
@@ -40,4 +40,19 @@ module "aws-sg-es" {
   tags             = var.tags
   ingress_protocol = "tcp"
   egress_protocol  = "all"
+}
+
+data "aws_subnet" "application_subnet" {
+  id = var.ec2_subnet_id
+}
+
+data "aws_subnet" "data_subnet_es" {
+  filter {
+    name   = "availability-zone"
+    values = [data.aws_subnet.application_subnet.availability_zone]
+  }
+  filter {
+    name   = "subnet-id"
+    values = toset(var.data_subnet_ids)
+  }
 }

--- a/examples/minimal/emr-cluster.tf
+++ b/examples/minimal/emr-cluster.tf
@@ -85,8 +85,8 @@ module "aws-emr-sg-service-access" {
   source              = "git::git@github.com:Datatamer/terraform-aws-security-groups.git?ref=1.0.0"
   vpc_id              = var.vpc_id
   ingress_cidr_blocks = var.ingress_cidr_blocks
-  egress_cidr_blocks  = var.egress_cidr_blocks
   ingress_ports       = module.sg-ports-emr.ingress_service_access_ports
+  egress_cidr_blocks  = var.egress_cidr_blocks
   sg_name_prefix      = format("%s-%s", var.name_prefix, "emr-service-access")
   egress_protocol     = "all"
   ingress_protocol    = "tcp"

--- a/examples/minimal/emr-cluster.tf
+++ b/examples/minimal/emr-cluster.tf
@@ -15,7 +15,7 @@ module "emr" {
   abac_valid_tags       = var.emr_abac_valid_tags
 
   # Networking
-  subnet_id                 = var.ec2_subnet_id
+  subnet_id                 = var.emr_subnet_id
   vpc_id                    = var.vpc_id
   emr_managed_master_sg_ids = module.aws-emr-sg-master.security_group_ids
   emr_managed_core_sg_ids   = module.aws-emr-sg-core.security_group_ids

--- a/examples/minimal/emr-cluster.tf
+++ b/examples/minimal/emr-cluster.tf
@@ -37,9 +37,10 @@ module "emr" {
   emr_ec2_instance_profile_name = "${var.name_prefix}-emr-instance-profile"
   emr_service_iam_policy_name   = "${var.name_prefix}-service-policy"
   emr_ec2_iam_policy_name       = "${var.name_prefix}-ec2-policy"
-  master_instance_group_name    = "${var.name_prefix}-MasterInstanceGroup"
-  core_instance_group_name      = "${var.name_prefix}-CoreInstanceGroup"
+  master_instance_fleet_name    = "${var.name_prefix}-MasterInstanceFleet"
+  core_instance_fleet_name      = "${var.name_prefix}-CoreInstanceFleet"
   emr_managed_sg_name           = "${var.name_prefix}-EMR-Managed"
+  emr_service_access_sg_name    = "${var.name_prefix}-EMR-Service-Access"
 
   # Scale
   master_instance_on_demand_count = 1

--- a/examples/minimal/emr-cluster.tf
+++ b/examples/minimal/emr-cluster.tf
@@ -45,10 +45,10 @@ module "emr" {
   # Scale
   master_instance_on_demand_count = 1
   core_instance_on_demand_count   = 4
-  master_instance_type = "m4.2xlarge"
-  core_instance_type   = "r5.2xlarge"
-  master_ebs_size      = 50
-  core_ebs_size        = 200
+  master_instance_type            = "m4.2xlarge"
+  core_instance_type              = "r5.2xlarge"
+  master_ebs_size                 = 50
+  core_ebs_size                   = 200
 }
 
 module "sg-ports-emr" {

--- a/examples/minimal/rds.tf
+++ b/examples/minimal/rds.tf
@@ -17,7 +17,7 @@ module "rds-postgres" {
 
   vpc_id = var.vpc_id
   # Network requirement: DB subnet group needs a subnet in at least two AZs
-  rds_subnet_ids = var.rds_subnet_group_ids
+  rds_subnet_ids = var.data_subnet_ids
 
   security_group_ids = module.rds-postgres-sg.security_group_ids
   tags               = var.tags

--- a/examples/minimal/tamr-vm.tf
+++ b/examples/minimal/tamr-vm.tf
@@ -8,6 +8,7 @@ module "tamr-vm" {
   vpc_id             = var.vpc_id
   security_group_ids = module.aws-sg-vm.security_group_ids
 
+  availability_zone           = data.aws_subnet.application_subnet.availability_zone
   aws_role_name               = "${var.name_prefix}-tamr-ec2-role"
   aws_instance_profile_name   = "${var.name_prefix}-tamrvm-instance-profile"
   aws_emr_creator_policy_name = "${var.name_prefix}-emr-creator-policy"

--- a/examples/minimal/tamr-vm.tf
+++ b/examples/minimal/tamr-vm.tf
@@ -1,13 +1,12 @@
 module "tamr-vm" {
   source = "git::git@github.com:Datatamer/terraform-emr-tamr-vm?ref=4.1.0"
 
-  ami                = var.ami_id
-  instance_type      = "m4.2xlarge"
-  key_name           = module.emr_key_pair.key_pair_key_name
-  subnet_id          = var.ec2_subnet_id
-  vpc_id             = var.vpc_id
-  security_group_ids = module.aws-sg-vm.security_group_ids
-
+  ami                         = var.ami_id
+  instance_type               = "r5.2xlarge"
+  key_name                    = module.emr_key_pair.key_pair_key_name
+  subnet_id                   = var.ec2_subnet_id
+  vpc_id                      = var.vpc_id
+  security_group_ids          = module.aws-sg-vm.security_group_ids
   availability_zone           = data.aws_subnet.application_subnet.availability_zone
   aws_role_name               = "${var.name_prefix}-tamr-ec2-role"
   aws_instance_profile_name   = "${var.name_prefix}-tamrvm-instance-profile"

--- a/examples/minimal/variables.tf
+++ b/examples/minimal/variables.tf
@@ -10,6 +10,12 @@ variable "ingress_cidr_blocks" {
   default     = []
 }
 
+variable "egress_cidr_blocks" {
+  type        = list(string)
+  description = "List of CIDR blocks from which ingress to ElasticSearch domain, Tamr VM, Tamr Postgres instance are allowed (i.e. VPN CIDR)"
+  default     = ["0.0.0.0/0"]
+}
+
 variable "ami_id" {
   type        = string
   description = "AMI to use for Tamr EC2 instance"
@@ -23,16 +29,6 @@ variable "license_key" {
 variable "vpc_id" {
   type        = string
   description = "VPC ID of deployment"
-}
-
-variable "ec2_subnet_id" {
-  type        = string
-  description = "Subnet ID for ElasticSearch domain, Tamr VM, EMR cluster"
-}
-
-variable "rds_subnet_group_ids" {
-  type        = list(string)
-  description = "List of at least 2 subnet IDs in different AZs"
 }
 
 variable "tags" {
@@ -51,4 +47,19 @@ variable "emr_abac_valid_tags" {
   type        = map(list(string))
   description = "Valid tags for maintaining resources when using ABAC IAM Policies with Tag Conditions. Make sure `emr_tags` contain the values specified here and that your Subnet is tagged as well"
   default     = {}
+}
+
+variable "emr_subnet_id" {
+  type        = string
+  description = "Subnet ID for EMR cluster"
+}
+
+variable "ec2_subnet_id" {
+  type        = string
+  description = "Subnet ID for Tamr VM"
+}
+
+variable "data_subnet_ids" {
+  type        = list(string)
+  description = "List of at least 2 subnet IDs in different AZs"
 }


### PR DESCRIPTION
- Separated subnets for Data, Application and Compute.
- Moved RDS and ES to the Data subnet
- Moved TamrVM to Application subnet
- Moved EMR to Compute subnet
- Removed AMI variable and replaced it with datasource to avoid AMI-Region confusion
- Fixed Tamr-VM defaulting to us-east-1